### PR TITLE
Treat compiler warnings for unused variables

### DIFF
--- a/code/parse-result/read.lisp
+++ b/code/parse-result/read.lisp
@@ -23,6 +23,7 @@
 (defmethod eclector.reader:call-as-top-level-read :around
     ((client parse-result-client) thunk input-stream
      eof-error-p eof-value preserve-whitespace-p)
+  (declare (ignore input-stream thunk preserve-whitespace-p))
   ;; We bind *CLIENT* here (instead of in, say, READ-AUX) to allow
   ;; (call-as-top-level-read
   ;;  client (lambda () ... (read-maybe-nothing client ...) ...) ...)
@@ -55,6 +56,7 @@
 
 (defmethod eclector.reader:read-maybe-nothing
     ((client parse-result-client) input-stream eof-error-p eof-value)
+  (declare (ignore eof-error-p eof-value))
   (let* ((stack (list* '() *stack*))
          (start (source-position client input-stream)))
     (multiple-value-bind (value what)

--- a/code/reader/fixup.lisp
+++ b/code/reader/fixup.lisp
@@ -1,12 +1,13 @@
 (cl:in-package #:eclector.reader)
 
 (defmethod fixup :around (client object seen-objects mapping)
+  (declare (ignore client mapping))
   (unless (gethash object seen-objects)
     (setf (gethash object seen-objects) t)
     (call-next-method)))
 
 (defmethod fixup (client object seen-objects mapping)
-  (declare (ignore seen-objects mapping))
+  (declare (ignore client object seen-objects mapping))
   nil)
 
 (macrolet ((fixup-place (place)

--- a/code/reader/generic-functions.lisp
+++ b/code/reader/generic-functions.lisp
@@ -73,6 +73,7 @@
 
 (defgeneric wrap-in-quote (client material)
   (:method (client material)
+    (declare (ignore client))
     (list 'quote material)))
 
 (defgeneric wrap-in-quasiquote (client form)

--- a/code/reader/read-common.lisp
+++ b/code/reader/read-common.lisp
@@ -29,6 +29,7 @@
 
 (defmethod call-as-top-level-read (client thunk input-stream
                                    eof-error-p eof-value preserve-whitespace-p)
+  (declare (ignore eof-error-p eof-value))
   (let* ((labels (make-hash-table))
          (values (multiple-value-list
                   (let ((*labels* labels))

--- a/code/reader/tokens.lisp
+++ b/code/reader/tokens.lisp
@@ -3,6 +3,7 @@
 ;;; Token Reading
 
 (defmethod read-token (client input-stream eof-error-p eof-value)
+  (declare (ignore eof-error-p eof-value))
   (let ((readtable *readtable*)
         (token (make-array 10
                            :element-type 'character
@@ -523,6 +524,7 @@
                                token escape-ranges
                                position-package-marker-1
                                position-package-marker-2)
+  (declare (ignore client))
   (let ((length (length token)))
     (cond ;; This signals an error for ":" and "::" but accepts ":||". "::" is
           ;; handled via TWO-PACKAGE-MARKERS-MUST-NOT-BE-FIRST.
@@ -566,6 +568,7 @@
 
 (defmethod interpret-symbol (client input-stream
                              (package-indicator null) symbol-name internp)
+  (declare (ignore client input-stream internp))
   (make-symbol symbol-name))
 
 ;;; INTERPRET-SYMBOL for interned symbols
@@ -650,6 +653,7 @@
 
 (defmethod interpret-symbol (client input-stream
                              package-indicator symbol-name internp)
+  (declare (ignore client))
   (prog (package symbol)
    package
      (setf package (case package-indicator


### PR DESCRIPTION
Am trying to have the build process of clasp free of compiler warnings (to be able to see `real` problems). I know that in clasp we use a different branch, but wanted to start upstream.

The only changes are various `(declare (ignore ..))`so they should be safe.

For testing i build clasp with this branch, run the regression-tests and also the ansi-tests with no regressions.