### PR TITLE
Minimal extension for ,. syntax

### DIFF
--- a/code/reader/generic-functions.lisp
+++ b/code/reader/generic-functions.lisp
@@ -181,6 +181,10 @@
     (declare (ignore client))
     (list 'unquote-splicing form)))
 
+(defgeneric wrap-in-unquote-nsplicing (client form)
+  (:method (client form)
+    (wrap-in-unquote-splicing client form)))
+
 (defgeneric wrap-in-function (client name)
   (:method (client name)
     (declare (ignore client))

--- a/code/reader/macro-functions.lisp
+++ b/code/reader/macro-functions.lisp
@@ -233,9 +233,12 @@
           (return-from comma (read-material))))
       (let* ((*backquote-depth* (1- depth))
              (form (read-material)))
-        (if splicing-p
-            (wrap-in-unquote-splicing client form)
-            (wrap-in-unquote client form))))))
+        (cond ((not splicing-p)
+               (wrap-in-unquote client form))
+              ((eql char2 #\.)
+               (wrap-in-unquote-nsplicing client form))
+              (t
+               (wrap-in-unquote-splicing client form)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/code/reader/package.lisp
+++ b/code/reader/package.lisp
@@ -133,6 +133,7 @@
    #:wrap-in-quasiquote
    #:wrap-in-unquote
    #:wrap-in-unquote-splicing
+   #:wrap-in-unquote-nsplicing
 
    #:wrap-in-function)
 


### PR DESCRIPTION
We have just added specializations of the `wrap-in-quote...`  generics to Clasp's eclector-client. Clasp does have destructive splicing (as rare as that is) but `,.` gets turned into `,@` by Eclector,

This PR is an idea for a minimal extension to enable destructive splicing without changing the signature of `wrap-in-unquote-splicing` and making the default for `wrap-in-unquote-nsplicing` be the appropriate specialization of `wrap-in-unquote-splicing`.

Obviously, error messages, tests, etc. could be updated.

FYI @Bike 