### PR TITLE
Fix a few ignored variables

### DIFF
--- a/code/parse-result/generic-functions.lisp
+++ b/code/parse-result/generic-functions.lisp
@@ -10,11 +10,11 @@
 
 (defgeneric source-position (client stream)
   (:method (client stream)
-    (eclector.base:source-position nil stream)))
+    (eclector.base:source-position client stream)))
 
 (defgeneric make-source-range (client start end)
   (:method (client start end)
-    (eclector.base:make-source-range nil start end)))
+    (eclector.base:make-source-range client start end)))
 
 ;;; Parse result protocol
 

--- a/code/parse-result/read.lisp
+++ b/code/parse-result/read.lisp
@@ -23,7 +23,8 @@
 (defmethod eclector.reader:call-as-top-level-read :around
     ((client parse-result-client) thunk input-stream
      eof-error-p eof-value preserve-whitespace-p)
-  (declare (ignore thunk input-stream preserve-whitespace-p))
+  (declare (ignore thunk input-stream preserve-whitespace-p
+                   eof-error-p eof-value))
   ;; We bind *CLIENT* here (instead of in, say, READ-AUX) to allow
   ;; (call-as-top-level-read
   ;;  client (lambda () ... (read-maybe-nothing client ...) ...) ...)


### PR DESCRIPTION
SBCL treats all method parameters as ignorable, but this is not required by the standard. Noticed these on Clasp.

The source location functions are deprecated anyway but I think it would be pretty confusing for anyone using them to just lose their client specializations? If it's intentional there should be `(declare (ignore client))` instead.